### PR TITLE
Drop third-party object-assign. Electron implements it natively.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "mime": "1.3.4",
     "musicmetadata": "2.0.4",
     "nedb": "1.8.0",
-    "object-assign": "4.1.0",
     "open-sans-fontface": "1.4.0",
     "react-bootstrap": "0.29.5",
     "react-dom": "15.2.1",

--- a/src/js/stores/AppStore.js
+++ b/src/js/stores/AppStore.js
@@ -5,7 +5,6 @@
 */
 
 import { EventEmitter } from 'events';
-import objectAssign     from 'object-assign';
 import path             from 'path';
 import fs               from 'fs';
 
@@ -26,7 +25,7 @@ const CHANGE_EVENT = 'change';
 |--------------------------------------------------------------------------
 */
 
-let AppStore = objectAssign({}, EventEmitter.prototype, {
+let AppStore = Object.assign({}, EventEmitter.prototype, {
 
     library           :  null,  // All tracks
 


### PR DESCRIPTION
Small nit I noticed while learning the codebase