### PR TITLE
Clean up styling of settings checkboxes

### DIFF
--- a/src/js/components/Settings/CheckboxSetting.react.js
+++ b/src/js/components/Settings/CheckboxSetting.react.js
@@ -26,16 +26,16 @@ export default class CheckboxSetting extends PureComponent {
 
         return (
             <div className='setting-section'>
-                <h4>{ this.props.title }</h4>
                 <div className='checkbox'>
                     <label>
                         <input type='checkbox'
                                onClick={ this.onClick }
                                defaultChecked={ this.props.defaultValue }
                         />
-                        { this.props.description }
-                        </label>
-                    </div>
+                        <span className='setting-title'>{ this.props.title }</span>
+                        <p className='setting-description'>{ this.props.description }</p>
+                    </label>
+                </div>
             </div>
         );
     }

--- a/src/js/components/Settings/SettingsUI.react.js
+++ b/src/js/components/Settings/SettingsUI.react.js
@@ -28,7 +28,7 @@ export default class SettingsUI extends Component {
         return (
             <div className='setting setting-interface'>
                 <CheckboxSetting
-                    title='Theme'
+                    title='Dark Theme'
                     description='Enable dark theme'
                     defaultValue={ config.theme === 'dark' }
                     onClick={ AppActions.settings.toggleDarkTheme }

--- a/src/styles/_view-settings.scss
+++ b/src/styles/_view-settings.scss
@@ -14,8 +14,21 @@
         border-top: 1px solid #d2d2d2;
         padding: 10px 15px;
 
-        .setting-section:not(:first-child) {
-            margin-top: 25px;
+        .setting-title {
+          font-weight: bold;
+          padding-top: 2px;
+        }
+
+        .setting-description {
+            font-size: 0.85em;
+            margin-top: 3px;
+        }
+
+        input[type="checkbox"] {
+          width: 2.5em;
+          height: 2.5em;
+          top: -0.8em;
+          left: 1.3em;
         }
     }
 }


### PR DESCRIPTION
Fixes #221

### Before:
<img width="413" alt="screen shot 2016-11-18 at 11 19 56 pm" src="https://cloud.githubusercontent.com/assets/1680080/20452980/94a651d4-ade5-11e6-9ffb-292871facb34.png">

### After:
<img width="348" alt="screen shot 2016-11-18 at 11 13 40 pm" src="https://cloud.githubusercontent.com/assets/1680080/20452957/d56affae-ade4-11e6-8ad1-6a238f23e052.png">
