### PR TITLE
Remove title from tray

### DIFF
--- a/src/main-process/tray.js
+++ b/src/main-process/tray.js
@@ -98,7 +98,6 @@ class IpcManager {
         this.tray = new Tray(this.trayIcon);
 
         this.tray.setToolTip('Museeks');
-        this.tray.setTitle('Museeks');
 
         if(os.platform() === 'win32') {
             this.tray.on('click', () => {


### PR DESCRIPTION
Adding the title makes it look a bit out of place.

Before:

![image](https://cloud.githubusercontent.com/assets/1680080/20525933/c01e071a-b08f-11e6-82e4-2ceaf0808c44.png)

After:
![image](https://cloud.githubusercontent.com/assets/1680080/20525990/0b434fa2-b090-11e6-8b27-3d3e38235dd7.png)
