### PR TITLE
Differentiate between prod and dev webpack builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:eslint": "./node_modules/.bin/eslint . --config .eslintrc",
     "compile": "webpack --config webpack.config.js --progress --colors",
     "lint": "eslint . --config .eslintrc --cache",
-    "dev": "webpack --config webpack.config.js --progress --colors --watch",
+    "dev": "webpack --config webpack.config.js --progress --colors --watch --development",
     "build": "npm run build:eslint && npm run build:compile && node build.js"
   },
   "dependencies": {
@@ -67,6 +67,7 @@
     "file-loader": "0.9.0",
     "install": "^0.8.2",
     "json-loader": "0.5.4",
+    "minimist": "^1.2.0",
     "node-sass": "3.13.0",
     "rimraf": "2.5.4",
     "sass-loader": "4.0.2",

--- a/src/js/components/Header/ButtonRepeat.react.js
+++ b/src/js/components/Header/ButtonRepeat.react.js
@@ -50,18 +50,18 @@ export default class ButtonRepeat extends Component {
 
     toggleRepeat() {
 
-        let repeat = false;
+        let repeat = 'none';
 
         switch(this.props.repeat) {
 
-            case false:
+            case 'none':
                 repeat = 'all';
                 break;
             case 'all':
                 repeat = 'one';
                 break;
             case 'one':
-                repeat = false;
+                repeat = 'none';
                 break;
         }
 

--- a/src/js/components/Shared/FullViewMessage.react.js
+++ b/src/js/components/Shared/FullViewMessage.react.js
@@ -9,7 +9,10 @@ import React, { PureComponent } from 'react';
 export default class FullViewMessage extends PureComponent {
 
     static propTypes = {
-        children: React.PropTypes.object
+        children: React.PropTypes.oneOfType([
+            React.PropTypes.array,
+            React.PropTypes.object
+        ])
     }
 
     constructor(props) {

--- a/src/js/components/Shared/TrackRow.react.js
+++ b/src/js/components/Shared/TrackRow.react.js
@@ -14,7 +14,7 @@ import classnames from 'classnames';
 export default class TrackRow extends Component {
 
     static propTypes = {
-        children: React.PropTypes.object,
+        children: React.PropTypes.array,
         selected: React.PropTypes.bool,
         trackId: React.PropTypes.string,
         index: React.PropTypes.number,

--- a/src/js/reducers/initial-state.js
+++ b/src/js/reducers/initial-state.js
@@ -25,7 +25,7 @@ export default {
     cover             :  null,  // Current trackplaying cover
     notifications     :  [],    // The array of notifications
     refreshingLibrary :  false, // If the app is currently refreshing the app
-    repeat            :  app.config.get('audioRepeat'), // the current repeat state (one, all, false)
+    repeat            :  app.config.get('audioRepeat'), // the current repeat state (one, all, none)
     shuffle           :  app.config.get('audioShuffle'), // If shuffle mode is enabled
     refreshProgress   :  0,     // Progress of the refreshing library
 };

--- a/src/main-process/config.js
+++ b/src/main-process/config.js
@@ -36,7 +36,7 @@ class ConfigManager {
             audioPlaybackRate: 1,
             audioMuted: false,
             audioShuffle: false,
-            audioRepeat: false,
+            audioRepeat: 'none',
             musicFolders: [],
             sleepBlocker: false,
             autoUpdateChecker: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,24 @@
+'use strict';
+
 const webpack           = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const BabiliPlugin      = require('babili-webpack-plugin');
 
-const path = require('path');
+const minimist = require('minimist');
+const path     = require('path');
+
+const commandline = minimist(process.argv.slice(2));
+
+let pluginsList;
+if (commandline.development) {
+    pluginsList = [new ExtractTextPlugin('main.css', { allChunks: true })];
+} else {
+    pluginsList = [
+        new BabiliPlugin(),
+        new webpack.DefinePlugin({ 'process.env': { 'NODE_ENV': '"production"' } }),
+        new ExtractTextPlugin('main.css', { allChunks: true }),
+    ];
+}
 
 module.exports = {
     entry: {
@@ -54,9 +70,6 @@ module.exports = {
             }
         ]
     },
-    plugins: [
-        new BabiliPlugin(),
-        new webpack.DefinePlugin({ 'process.env': { 'NODE_ENV': '"production"' } }),
-        new ExtractTextPlugin('main.css', { allChunks: true }),
-    ]
+    plugins: pluginsList,
+    devtool: commandline.development ? 'source-map' : undefined
 };


### PR DESCRIPTION
- Use `minimist` to parse CLI flags nicely
- Fix some of the props warnings that popped out in dev mode (we should do more in #279)
- Don't use minificator and prod env in development
- Enable sourcemaps

![image](https://cloud.githubusercontent.com/assets/2168518/20681729/e445772e-b5b5-11e6-9b09-41037fd74684.png)


Refs: #169 