### PR TITLE
Fix proptypes validation across the app

### DIFF
--- a/src/js/components/App.react.js
+++ b/src/js/components/App.react.js
@@ -36,6 +36,8 @@ class Museeks extends Component {
         const store = this.props.store;
         const trackPlayingId = (store.queue.length > 0 && store.queueCursor !== null) ? store.queue[store.queueCursor]._id : null;
 
+        const config = { ...app.config.getAll() };
+
         return (
             <div className='main'>
                 <KeyBinding onKey={ this.onKey } preventInputConflict />
@@ -47,14 +49,14 @@ class Museeks extends Component {
                     cover={ store.cover }
                     queue={ store.queue }
                     queueCursor={ store.queueCursor }
-                    windowControls={ !{ ...app.config.getAll() }.useNativeFrame }
+                    windowControls={ !config.useNativeFrame }
                 />
                 <div className='main-content'>
                     <Row className='content'>
                         { React.cloneElement(
                             this.props.children, {
                                 app               : this,
-                                config            : { ...app.config.getAll() },
+                                config,
                                 queue             : store.queue,
                                 tracks            : store.tracks[store.tracksCursor].sub,
                                 library           : store.tracks[store.tracksCursor].all,

--- a/src/js/components/Header/QueueList.react.js
+++ b/src/js/components/Header/QueueList.react.js
@@ -71,12 +71,13 @@ export default class QueueList extends Component {
                     { shownQueue.map((track, index) => {
                         return (
                             <QueueListItem
+                                key={ index }
                                 index={ index }
                                 track={ track }
                                 queueCursor={ this.props.queueCursor }
                                 dragged={ index === self.state.draggedTrackIndex }
                                 draggedOver={ index === self.state.draggedOverTrackIndex }
-                                dragPosition={ index === self.state.draggedOverTrackIndex && self.state.dragPosition }
+                                dragPosition={ index === self.state.draggedOverTrackIndex && self.state.dragPosition || null }
                                 onDragStart={ self.dragStart }
                                 onDragOver={ this.dragOver }
                                 onDragEnd={ self.dragEnd }

--- a/src/js/components/Playlists/PlaylistsNavLink.react.js
+++ b/src/js/components/Playlists/PlaylistsNavLink.react.js
@@ -11,7 +11,7 @@ import { Link } from 'react-router';
 export default class PlaylistsNavLink extends Component {
 
     static propTypes = {
-        children: React.PropTypes.object,
+        children: React.PropTypes.string,
         playlistId: React.PropTypes.string,
         onContextMenu: React.PropTypes.func
     }

--- a/src/js/components/Settings/LibraryFolders.react.js
+++ b/src/js/components/Settings/LibraryFolders.react.js
@@ -32,6 +32,7 @@ export default class LibraryFolders extends Component {
                 { this.props.folders.map((folder, i) => {
                     return (
                         <LibraryFolder
+                            key={ i }
                             index={ i }
                             folder={ folder }
                             refreshingLibrary={ this.props.refreshingLibrary }

--- a/src/js/components/Settings/Settings.react.js
+++ b/src/js/components/Settings/Settings.react.js
@@ -12,7 +12,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 export default class Settings extends Component {
 
     static propTypes = {
-        config: React.PropTypes.object.isRequired,
+        config: React.PropTypes.object,
         refreshingLibrary: React.PropTypes.bool,
         refreshProgress: React.PropTypes.number,
         children: React.PropTypes.object

--- a/src/js/components/Settings/SettingsAdvanced.react.js
+++ b/src/js/components/Settings/SettingsAdvanced.react.js
@@ -14,7 +14,7 @@ import CheckboxSetting from './CheckboxSetting.react';
 export default class SettingsAdvanced extends Component {
 
     static propTypes = {
-        config: React.PropTypes.object.isRequired
+        config: React.PropTypes.object
     }
 
     constructor(props) {

--- a/src/js/components/Settings/SettingsAudio.react.js
+++ b/src/js/components/Settings/SettingsAudio.react.js
@@ -12,7 +12,7 @@ import AppActions from '../../actions/AppActions';
 export default class SettingsAudio extends Component {
 
     static propTypes = {
-        config: React.PropTypes.object.isRequired
+        config: React.PropTypes.object
     }
 
     constructor(props) {

--- a/src/js/components/Settings/SettingsLibrary.react.js
+++ b/src/js/components/Settings/SettingsLibrary.react.js
@@ -17,7 +17,7 @@ import AppActions from '../../actions/AppActions';
 export default class SettingsLibrary extends Component {
 
     static propTypes = {
-        config: React.PropTypes.object.isRequired,
+        config: React.PropTypes.object,
         refreshingLibrary: React.PropTypes.bool,
         refreshProgress: React.PropTypes.number
     }

--- a/src/js/components/Settings/SettingsUI.react.js
+++ b/src/js/components/Settings/SettingsUI.react.js
@@ -14,7 +14,7 @@ import CheckboxSetting from './CheckboxSetting.react';
 export default class SettingsUI extends Component {
 
     static propTypes = {
-        config: React.PropTypes.object.isRequired
+        config: React.PropTypes.object
     }
 
     constructor(props) {

--- a/src/js/components/Shared/ExternalLink.react.js
+++ b/src/js/components/Shared/ExternalLink.react.js
@@ -13,7 +13,7 @@ export default class ExternalLink extends Component {
 
     static propTypes = {
         href: React.PropTypes.string,
-        children: React.PropTypes.object
+        children: React.PropTypes.string
     }
 
     constructor(props) {


### PR DESCRIPTION
fix #279

I removed the required option because the proptypes were checked before receiving the props. Yes that' super weird, I don't know why.