### PR TITLE
Add a snap package (https://snapcraft.io)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,11 +61,19 @@
     "linux": {
       "category": "AudioVideo",
       "target": [
+        "snap",
         "deb",
         "rpm",
         "AppImage"
       ],
       "executableName": "museeks"
+    },
+    "snap": {
+      "plugs": [
+        "default",
+        "desktop-legacy",
+        "desktop"
+      ]
     },
     "win": {
       "target": "nsis",
@@ -114,7 +122,7 @@
     "clean-terminal-webpack-plugin": "1.0.1",
     "css-loader": "0.28.7",
     "electron": "1.7.10",
-    "electron-builder": "19.52.1",
+    "electron-builder": "19.53.0",
     "eslint": "4.14.0",
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-react": "7.5.1",


### PR DESCRIPTION
Hi :)

I've put together this PR to add a snap package. I've tested it on Ubuntu 16.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm install; npm run package:l` it will create `dist/museeks_0.8.1_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous museeks_0.8.1_amd64.snap`

Execute with `museeks` from the terminal or find it in the launcher.

If you create a developer account and push museeks to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the account, [sign up here](https://dashboard.snapcraft.io/register-snap/), then register the "museeks" name.

You'll need the snapcraft command to push the snap file to the store:
 * If you're on a Mac, you can `brew install snapcraft`
 * If you're on Linux, `sudo snap install --classic snapcraft`

Then push it to the store with:
```snapcraft push museeks_0.8.1_amd64.snap --release stable```

You'll then see it on https://snapcraft.io/museeks and anyone can `snap install museeks`. Let me know what you think.